### PR TITLE
Anonymize user paths in logs with PathHelpers

### DIFF
--- a/MyScheduledTasks/App.xaml.cs
+++ b/MyScheduledTasks/App.xaml.cs
@@ -146,6 +146,7 @@ public partial class App : Application
     #region Language testing
     private void CheckLanguageTesting()
     {
+        TestLanguageFile = string.Empty;
         if (UserSettings.Setting!.LanguageTesting)
         {
             _log.Info("Language testing enabled");
@@ -161,12 +162,12 @@ public partial class App : Application
                         Resources.MergedDictionaries.Add(testDict);
                         TestLanguageStrings = testDict.Count;
                         TestLanguageFile = testDict.Source.OriginalString;
-                        _log.Debug($"{TestLanguageStrings} strings loaded from {TestLanguageFile}");
+                        _log.Debug($"{TestLanguageStrings} strings loaded from {PathHelpers.AnonymizePath(TestLanguageFile)}");
                     }
                 }
                 catch (Exception ex)
                 {
-                    _log.Error(ex, $"Error loading test language file {TestLanguageFile}");
+                    _log.Error(ex, $"Error loading test language file {PathHelpers.AnonymizePath(TestLanguageFile)}");
                     string msg = string.Format(CultureInfo.CurrentCulture,
                                                $"{GetStringResource("MsgText_Error_TestLanguage")}\n\n{ex.Message}\n\n{ex.InnerException}");
                     _ = MessageBox.Show(msg,
@@ -177,7 +178,7 @@ public partial class App : Application
             }
             else
             {
-                _log.Error($"Error loading test language file {TestLanguageFile}. File not found.");
+                _log.Error($"Error loading test language file {PathHelpers.AnonymizePath(TestLanguageFile)}. File not found.");
             }
         }
     }

--- a/MyScheduledTasks/Configuration/ConfigHelpers.cs
+++ b/MyScheduledTasks/Configuration/ConfigHelpers.cs
@@ -105,7 +105,7 @@ internal static class ConfigHelpers
 
             if (saveFile.ShowDialog() == true)
             {
-                _log.Debug($"Exporting settings file to {saveFile.FileName}.");
+                _log.Debug($"Exporting settings file to {PathHelpers.AnonymizePath(saveFile.FileName)}.");
                 string json = JsonSerializer.Serialize(UserSettings.Setting, _options);
                 File.WriteAllText(saveFile.FileName, json);
             }
@@ -140,7 +140,7 @@ internal static class ConfigHelpers
             if (importFile.ShowDialog() == true)
             {
                 _log.Debug($"Importing settings file from {importFile.FileName}.");
-                ConfigManager<UserSettings>.Setting = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(importFile.FileName))!;
+                ConfigManager<UserSettings>.Setting = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(PathHelpers.AnonymizePath(importFile.FileName)));
                 SaveSettings();
 
                 _ = new MDCustMsgBox($"{GetStringResource("MsgText_ImportSettingsRestart")}",

--- a/MyScheduledTasks/Configuration/ConfigHelpers.cs
+++ b/MyScheduledTasks/Configuration/ConfigHelpers.cs
@@ -139,8 +139,8 @@ internal static class ConfigHelpers
 
             if (importFile.ShowDialog() == true)
             {
-                _log.Debug($"Importing settings file from {importFile.FileName}.");
-                ConfigManager<UserSettings>.Setting = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(PathHelpers.AnonymizePath(importFile.FileName)));
+                _log.Debug($"Importing settings file from {PathHelpers.AnonymizePath(importFile.FileName)}.");
+                ConfigManager<UserSettings>.Setting = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(importFile.FileName));
                 SaveSettings();
 
                 _ = new MDCustMsgBox($"{GetStringResource("MsgText_ImportSettingsRestart")}",

--- a/MyScheduledTasks/Helpers/MainWindowHelpers.cs
+++ b/MyScheduledTasks/Helpers/MainWindowHelpers.cs
@@ -140,7 +140,7 @@ internal static class MainWindowHelpers
         // Log the version, build date and commit id
         _log.Info($"{AppInfo.AppName} ({AppInfo.AppProduct}) {BuildInfo.VersionString} {GetStringResource("MsgText_ApplicationStarting")}");
         _log.Info($"{AppInfo.AppName} {AppInfo.AppCopyright}");
-        _log.Debug($"{AppInfo.AppName} was started from {AppInfo.AppPath}");
+        _log.Debug($"{AppInfo.AppName} was started from {PathHelpers.AnonymizePath(AppInfo.AppPath)}");
         _log.Debug($"{AppInfo.AppName} Build date: {BuildInfo.BuildDateStringUtc}");
         _log.Debug($"{AppInfo.AppName} Commit ID: {BuildInfo.CommitIDString}");
         _log.Debug($"{AppInfo.AppName} Process ID: {AppInfo.AppProcessID}");

--- a/MyScheduledTasks/Helpers/PathHelpers.cs
+++ b/MyScheduledTasks/Helpers/PathHelpers.cs
@@ -22,10 +22,9 @@ internal static class PathHelpers
         }
 
         string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        if (!path.StartsWith(userProfile, StringComparison.CurrentCultureIgnoreCase))
+        if (!path.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
         {
             return path;
         }
-        return path.Replace(userProfile, "%USERPROFILE%");
-    }
+        return $"%USERPROFILE%{path[userProfile.Length..]}";
 }

--- a/MyScheduledTasks/Helpers/PathHelpers.cs
+++ b/MyScheduledTasks/Helpers/PathHelpers.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace MyScheduledTasks.Helpers;
+
+internal static class PathHelpers
+{
+    /// <summary>
+    /// If a path to a file includes the user profile name replace it with %USERPROFILE%.
+    /// </summary>
+    /// <remarks>
+    /// Users may not want to have their user names visible in the log file, especially when sending that log with a bug
+    /// report. This method accomplishes that while still keeping the logged path usable.
+    /// </remarks>
+    /// <returns>
+    /// A string representing the path.
+    /// </returns>
+    public static string AnonymizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return string.Empty;
+        }
+
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!path.StartsWith(userProfile, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return path;
+        }
+        return path.Replace(userProfile, "%USERPROFILE%");
+    }
+}

--- a/MyScheduledTasks/Helpers/TaskFileHelpers.cs
+++ b/MyScheduledTasks/Helpers/TaskFileHelpers.cs
@@ -41,12 +41,12 @@ internal static class TaskFileHelpers
         {
             string json = File.ReadAllText(TasksFile);
             MyTasks.MyTasksCollection = JsonSerializer.Deserialize<ObservableCollection<MyTasks>>(json)!;
-            _log.Info($"Read {MyTasks.MyTasksCollection.Count} items from {TasksFile} ");
+            _log.Info($"Read {MyTasks.MyTasksCollection.Count} items from {PathHelpers.AnonymizePath(TasksFile)} ");
         }
         // Can't really do much if the file is not readable
         catch (Exception ex)
         {
-            _log.Fatal(ex, $"Error reading {TasksFile}");
+            _log.Fatal(ex, $"Error reading {PathHelpers.AnonymizePath(TasksFile)}");
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorReadingFile, TasksFile);
             msg += $"\n\n{ex.Message}\n\n{GetStringResource("MsgText_ErrorFatal")}";
             _ = new MDCustMsgBox(msg,
@@ -74,7 +74,7 @@ internal static class TaskFileHelpers
         }
         catch (Exception ex)
         {
-            _log.Fatal(ex, $"Error creating {TasksFile}");
+            _log.Fatal(ex, $"Error creating {PathHelpers.AnonymizePath(TasksFile)}");
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorCreatingFile, TasksFile);
             msg += $"\n\n{ex.Message}\n\n{GetStringResource("MsgText_ErrorFatal")}";
             _ = new MDCustMsgBox(msg,
@@ -102,7 +102,7 @@ internal static class TaskFileHelpers
         {
             string tasks = JsonSerializer.Serialize(MyTasks.MyTasksCollection, _options);
             File.WriteAllText(TasksFile, tasks);
-            _log.Info($"Saving {MyTasks.MyTasksCollection!.Count} tasks to {TasksFile} ");
+            _log.Info($"Saving {MyTasks.MyTasksCollection!.Count} tasks to {PathHelpers.AnonymizePath(TasksFile)} ");
             if (!quiet)
             {
                 SnackbarMsg.QueueMessage(GetStringResource("MsgText_FileSaved"), 3000);
@@ -111,7 +111,7 @@ internal static class TaskFileHelpers
         }
         catch (Exception ex)
         {
-            _log.Error(ex, $"Error saving {TasksFile}");
+            _log.Error(ex, $"Error saving {PathHelpers.AnonymizePath(TasksFile)}");
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorSavingFile, TasksFile);
             msg += $"\n\n{ex.Message}";
             _ = new MDCustMsgBox(msg,

--- a/MyScheduledTasks/Helpers/TaskFileHelpers.cs
+++ b/MyScheduledTasks/Helpers/TaskFileHelpers.cs
@@ -46,7 +46,7 @@ internal static class TaskFileHelpers
         // Can't really do much if the file is not readable
         catch (Exception ex)
         {
-            _log.Fatal(ex, $"Error reading {PathHelpers.AnonymizePath(TasksFile)}");
+            _log.Fatal($"Error reading {PathHelpers.AnonymizePath(TasksFile)}");
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorReadingFile, TasksFile);
             msg += $"\n\n{ex.Message}\n\n{GetStringResource("MsgText_ErrorFatal")}";
             _ = new MDCustMsgBox(msg,
@@ -74,7 +74,7 @@ internal static class TaskFileHelpers
         }
         catch (Exception ex)
         {
-            _log.Fatal(ex, $"Error creating {PathHelpers.AnonymizePath(TasksFile)}");
+            _log.Fatal($"Error creating {PathHelpers.AnonymizePath(TasksFile)}");
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorCreatingFile, TasksFile);
             msg += $"\n\n{ex.Message}\n\n{GetStringResource("MsgText_ErrorFatal")}";
             _ = new MDCustMsgBox(msg,
@@ -111,7 +111,7 @@ internal static class TaskFileHelpers
         }
         catch (Exception ex)
         {
-            _log.Error(ex, $"Error saving {PathHelpers.AnonymizePath(TasksFile)}");
+            _log.Error($"Error saving {PathHelpers.AnonymizePath(TasksFile)}");
             string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorSavingFile, TasksFile);
             msg += $"\n\n{ex.Message}";
             _ = new MDCustMsgBox(msg,

--- a/MyScheduledTasks/Helpers/TaskHelpers.cs
+++ b/MyScheduledTasks/Helpers/TaskHelpers.cs
@@ -374,7 +374,7 @@ internal static class TaskHelpers
 
             GetAllTasks();
 
-            _log.Info($"Imported {TempSettings.Setting.ImportXMLFile} to \"{TempSettings.Setting.ImportTaskName}\"");
+            _log.Info($"Imported {PathHelpers.AnonymizePath(TempSettings.Setting.ImportXMLFile)} to \"{TempSettings.Setting.ImportTaskName}\"");
             SnackbarMsg.ClearAndQueueMessage($"{TempSettings.Setting.ImportXMLFile} {GetStringResource("ImportTask_ImportSuccess")}");
             MDCustMsgBox mbox = new($"{TempSettings.Setting.ImportXMLFile} {GetStringResource("ImportTask_ImportSuccess")}",
                     GetStringResource("ImportTask_ImportSuccessHeader"),
@@ -395,7 +395,7 @@ internal static class TaskHelpers
         }
         catch (Exception ex)
         {
-            _log.Error(ex, $"Error Importing {TempSettings.Setting.ImportXMLFile}");
+            _log.Error(ex, $"Error Importing {PathHelpers.AnonymizePath(TempSettings.Setting.ImportXMLFile)}");
             MDCustMsgBox mbox = new($"{GetStringResource("ImportTask_ImportErrorGeneral")}\n\n{ex.Message}",
                     GetStringResource("ImportTask_ImportErrorHeader"),
                     ButtonType.Ok,

--- a/MyScheduledTasks/Helpers/TextFileViewer.cs
+++ b/MyScheduledTasks/Helpers/TextFileViewer.cs
@@ -19,13 +19,17 @@ public static class TextFileViewer
     ///
     public static void ViewTextFile(string textFile)
     {
+        string fname = string.Empty;
         try
         {
+            fname = PathHelpers.AnonymizePath(textFile);
+
             using Process p = new();
             p.StartInfo.FileName = textFile;
             p.StartInfo.UseShellExecute = true;
             p.StartInfo.ErrorDialog = false;
             _ = p.Start();
+            _log.Debug($"Opening {fname}.");
         }
         catch (Win32Exception ex)
         {
@@ -37,7 +41,7 @@ public static class TextFileViewer
                 p.StartInfo.UseShellExecute = true;
                 p.StartInfo.ErrorDialog = false;
                 _ = p.Start();
-                _log.Debug($"Opening {textFile} in Notepad.exe");
+                _log.Debug($"Opening {fname} in Notepad.exe");
             }
             else
             {
@@ -48,7 +52,7 @@ public static class TextFileViewer
                                     MessageBoxButton.OK,
                                     MessageBoxImage.Error);
 #endif
-                _log.Error(ex, $"Unable to open {textFile}");
+                _log.Error(ex, $"Unable to open {fname}");
             }
         }
         catch (Exception ex)
@@ -60,7 +64,7 @@ public static class TextFileViewer
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Error);
 #endif
-            _log.Error(ex, $"Unable to open {textFile}");
+            _log.Error(ex, $"Unable to open {fname}");
         }
     }
     #endregion Text file viewer

--- a/MyScheduledTasks/ViewModels/SettingsViewModel.cs
+++ b/MyScheduledTasks/ViewModels/SettingsViewModel.cs
@@ -63,7 +63,7 @@ internal sealed partial class SettingsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            _log.Error(ex, $"Error trying to open {filePath}: {ex.Message}");
+            _log.Error(ex, $"Error trying to open {PathHelpers.AnonymizePath(filePath)}: {ex.Message}");
             _ = new MDCustMsgBox(GetStringResource("MsgText_Error_FileExplorer"),
                      "My Scheduled Tasks ERROR",
                      ButtonType.Ok,


### PR DESCRIPTION
Anonymize user paths in logs with PathHelpers

Added PathHelpers.AnonymizePath to replace user profile paths with %USERPROFILE% in log messages. Updated all relevant logging and error handling to use anonymized paths, enhancing privacy when sharing logs.