### PR TITLE
Migrate project to x64 only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,9 +338,11 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+
 MyScheduledTasks/Properties/launchSettings.json
 
 MyScheduledTasks/.editorconfig
 
 # override .gitignore_global 
 !MyScheduledTasks/BuildInfo.cs
+!**/*.pubxml

--- a/MyScheduledTasks.slnx
+++ b/MyScheduledTasks.slnx
@@ -1,9 +1,8 @@
 <Solution>
   <Configurations>
-    <Platform Name="Any CPU" />
     <Platform Name="x64" />
   </Configurations>
   <Project Path="MyScheduledTasks/MyScheduledTasks.csproj">
-    <Platform Solution="*|x64" Project="x64" />
+    <Platform Project="x64" />
   </Project>
 </Solution>

--- a/MyScheduledTasks/Inno_Setup/MyScheduledTasks.iss
+++ b/MyScheduledTasks/Inno_Setup/MyScheduledTasks.iss
@@ -159,8 +159,7 @@ var
   Text: String;
 begin
   case ExpandConstant('{#InstallType}') of
-    'x64x86': Text := FmtMessage( CustomMessage('NotSelfContained'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]);
-    'SC_x86': Text := FmtMessage( CustomMessage('SelfContainedx86'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]);
+    'FD_x64': Text := FmtMessage( CustomMessage('NotSelfContained64'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]);
     'SC_x64': Text := FmtMessage( CustomMessage('SelfContainedx64'), [ExpandConstant('{#MyAppName}'), ExpandConstant('{#MyAppVersion}')]);
   else
       Text := WizardForm.WelcomeLabel2.Caption;

--- a/MyScheduledTasks/Inno_Setup/MyScheduledTasks.localization.iss
+++ b/MyScheduledTasks/Inno_Setup/MyScheduledTasks.localization.iss
@@ -45,80 +45,70 @@ sk.SetupWindowTitle = Sprievodca inštaláciou - {#MyAppName} {#MyAppVersion}
 ;
 [CustomMessages]
 en.AppIsRunning=is running, please close it to continue with the installation.
-en.DeleteConfigFiles=Do you want to remove the settings files?%n%nSelect 'No' if you plan on reinstalling.
-en.NotSelfContained=This will install the standard version of %1 version %2.%n%nThis version requires an existing installation of .NET 10 Desktop Runtime and is compatible with both x64 and x86 systems.%n%nIt is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
+en.DeleteConfigFiles=Do you want to remove the settings and history files and registry entries?%n%nSelect 'No' if you plan to reinstall the program.
+en.NotSelfContained64=This will install the framework-dependent x64 (64-bit) version of %1 version %2.%n%nThis version requires an existing installation of .NET 10 Desktop Runtime.%n%nIt is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
 en.SelfContainedx64=This will install the self-contained x64 (64-bit) version of %1 version %2.%n%nIt is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
-en.SelfContainedx86=This will install the self-contained x86 (32-bit) version of %1 version %2.%n%nIt is recommended that you close all other applications before continuing.%n%nClick 'Next' to continue, or 'Cancel' to exit Setup.
 en.ViewReadme=View the ReadMe file
 ;
 ;
-ca.AppIsRunning=s'està executant, tanqueu-lo per continuar amb la instal·lació.
-ca.DeleteConfigFiles=Voleu eliminar la configuració i excloure fitxers?%n%nSeleccioneu 'No' si teniu previst tornar a instal·lar.
-ca.NotSelfContained=Aquesta versió requereix una instal·lació existent de .NET 10 Desktop Runtime i és compatible tant amb sistemes x64 com x86.%n%nEs recomana tancar totes les altres aplicacions abans de continuar.%n%nFeu clic a 'Següent' per continuar, o 'Cancel·la' per sortir de la instal·lació.
-ca.SelfContainedx64=Això instal·larà la versió autònoma x64 (64 bits) de %1 versió %2.%n%nEs recomana tancar totes les altres aplicacions abans de continuar.%n%nFeu clic a "Següent" per continuar o a "Cancel·lar" per sortir de la instal·lació.
-ca.SelfContainedx86=Això instal·larà la versió x86 (32-bit) autònoma de %1 versió %2.%n%nEs recomana tancar totes les altres aplicacions abans de continuar.%n%nFeu clic a "Següent" per continuar o "Cancel·lar" per sortir de la instal·lació.
+ca.AppIsRunning=està en execució, tanqueu-lo per continuar amb la instal·lació.
+ca.DeleteConfigFiles=Voleu eliminar els fitxers de configuració, l'historial i les entrades del registre?%n%nSeleccioneu "No" si teniu previst reinstal·lar el programa.
+ca.NotSelfContained64=Això instal·larà la versió x64 (64 bits) dependent del framework de %1 versió %2.%n%nAquesta versió requereix una instal·lació existent de .NET 10 Desktop Runtime.%n%nEs recomana que tanqueu totes les altres aplicacions abans de continuar.%n%nFeu clic a "Següent" per continuar o a "Cancel·la" per sortir del programa d'instal·lació.
+ca.SelfContainedx64=Això instal·larà la versió autònoma x64 (64 bits) de %1 versió %2.%n%nEs recomana tancar totes les altres aplicacions abans de continuar.%n%nFeu clic a "Següent" per continuar o a "Cancel·la" per sortir del programa d'instal·lació.
 ca.ViewReadme=Veure el fitxer ReadMe
 ;
 ;
 de.AppIsRunning=ausgeführt wird, schließen Sie es bitte, um mit der Installation fortzufahren.
-de.DeleteConfigFiles=Möchten Sie die Einstellungen und Ausschlussdateien entfernen?%n%nWählen Sie 'Nein', wenn Sie eine Neuinstallation planen.
-de.NotSelfContained=Dadurch wird die Standardversion %1 Version %2 installiert.%n%nDiese Version erfordert eine bestehende Installation der .NET 10 Desktop Runtime und ist sowohl mit x64- als auch mit x86-Systemen kompatibel.%n%nEs wird empfohlen, dass Sie alle anderen Anwendungen schließen, bevor Sie fortfahren.%n%nKlicken Sie auf "Weiter", um fortzufahren, oder auf "Abbrechen", um das Setup zu beenden.
-de.SelfContainedx64=Dadurch wird die eigenständige x64 (64-Bit)-Version von %1 Version %2 installiert.%n%nEs wird empfohlen, dass Sie alle anderen Anwendungen schließen, bevor Sie fortfahren.%n%nKlicken Sie auf "Weiter", um fortzufahren, oder auf "Abbrechen", um das Setup zu beenden.
-de.SelfContainedx86=Dadurch wird die eigenständige x86 (32-Bit)-Version von %1 Version %2 installiert.%n%nEs wird empfohlen, dass Sie alle anderen Anwendungen schließen, bevor Sie fortfahren.%n%nKlicken Sie auf "Weiter", um fortzufahren, oder auf "Abbrechen", um das Setup zu beenden.
+de.DeleteConfigFiles=Möchten Sie die Einstellungs- und Verlaufsdateien sowie die Registrierungseinträge entfernen?%n%nWählen Sie „Nein“, wenn Sie das Programm neu installieren möchten.
+de.NotSelfContained64=Dadurch wird die frameworkabhängige x64-Version (64-Bit) von %1 Version %2 installiert.%n%nDiese Version erfordert eine bestehende Installation der .NET 10 Desktop Runtime.%n%nEs wird empfohlen, alle anderen Anwendungen vor dem Fortfahren zu schließen.%n%nKlicken Sie auf „Weiter“, um fortzufahren, oder auf „Abbrechen“, um die Installation zu beenden.
+de.SelfContainedx64=Dadurch wird die eigenständige x64-Version (64-Bit) von %1 Version %2 installiert. Es wird empfohlen, vor dem Fortfahren alle anderen Anwendungen zu schließen. Klicken Sie auf „Weiter“, um fortzufahren, oder auf „Abbrechen“, um die Installation zu beenden.
 de.ViewReadme=Lesen Sie die ReadMe-Datei
 ;
 ;
 es.AppIsRunning=se está ejecutando, por favor ciérrelo para continuar con la instalación.
-es.DeleteConfigFiles=¿Desea eliminar la configuración y excluir archivos?%n%nSeleccione 'No' si planea reinstalar.
-es.NotSelfContained=Esto instalará la versión estándar de la versión %2 de %1.%n%nEsta versión requiere una instalación existente de .NET 10 Desktop Runtime y es compatible con los sistemas x64 y x86.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
-es.SelfContainedx64=Esto instalará la versión x64 (64 bits) independiente de la versión %2 de %1.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
-es.SelfContainedx86=Esto instalará la versión x86 (32 bits) independiente de la versión %2 de %1.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
+es.DeleteConfigFiles=¿Desea eliminar la configuración y los archivos de historial y entradas del registro?%n%nSeleccione 'No' si planea reinstalar el programa.
+es.NotSelfContained64=Esto instalará la versión x64 (64 bits) dependiente del marco de %1 versión %2.%n%nEsta versión requiere una instalación existente de .NET 10 Desktop Runtime.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
+es.SelfContainedx64=Esto instalará la versión x64 (64 bits) independiente portátil de %1 versión %2.%n%nSe recomienda cerrar todas las demás aplicaciones antes de continuar.%n%nHaga clic en 'Siguiente' para continuar o en 'Cancelar' para salir de la configuración.
 es.ViewReadme=Abrir el archivo Léame
 ;
 ;
 fr.AppIsRunning=est en cours d'exécution, veuillez le fermer pour poursuivre l'installation.
-fr.DeleteConfigFiles=Voulez-vous supprimer les paramètres et les fichiers d'exclusion ?%n%nSélectionnez 'Non' si vous prévoyez de réinstaller.
-fr.NotSelfContained=Ceci installera la version standard de %1 version %2.%n%nCette version nécessite une installation existante de .NET 10 Desktop Runtime et est compatible avec les systèmes x64 et x86.%n%nIl est recommandé de fermer toutes les autres applications avant de continuer.%n%nCliquez sur "Suivant" pour continuer ou sur "Annuler" pour quitter le programme d’installation.
-fr.SelfContainedx64=Ceci installera la version autonome x64 (64 bits) de %1 version %2.%n%nIl est recommandé de fermer toutes les autres applications avant de continuer.%n%nCliquez sur "Suivant" pour continuer, ou sur "Annuler" pour quitter l'installation.
-fr.SelfContainedx86=Ceci installera la version x86 (32 bits) de %1 version %2.%n%nIl est recommandé de fermer toutes les autres applications avant de continuer.%n%nCliquez sur 'Suivant' pour continuer, ou 'Annuler' pour quitter l'installation.
+fr.DeleteConfigFiles=Voulez-vous supprimer les fichiers de paramètres et d'historique ainsi que les entrées de registre ?%n%nSélectionnez « Non » si vous prévoyez de réinstaller le programme.
+fr.NotSelfContained64=Cela installera la version x64 (64 bits) dépendante du framework de %1 version %2.%n%nCette version nécessite une installation existante de .NET 10 Desktop Runtime.%n%nIl est recommandé de fermer toutes les autres applications avant de continuer.%n%nCliquez sur « Suivant » pour continuer ou sur « Annuler » pour quitter l’installation.
+fr.SelfContainedx64=Ceci installera la version x64 (64 bits) autonome de %1 version %2.%n%nIl est recommandé de fermer toutes les autres applications avant de continuer.%n%nCliquez sur « Suivant » pour continuer, ou sur « Annuler » pour quitter l'installation.
 fr.ViewReadme=Voir le fichier ReadMe
 ;
 ;
 it.AppIsRunning=è in esecuzione, per continuare l'installazione chiudi l'applicazione.
-it.DeleteConfigFiles=Vuoi rimuovere le impostazioni del programma?%n%nSe vuoi reinstallare il programma più avanti seleziona 'No'.
-it.NotSelfContained=Verrà installata la versione standard di %1 %2.%n%nQuesta versione richiede che sia già installato .NET 10 Desktop Runtime ed è compatibile con i sistemi 32bit e 64bit.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nPer continuare seleziona 'Avanti' o 'Annulla' per uscire dall'installazione.
-it.SelfContainedx64=Verrà installata la versione standalone di %1 %2 64 bit.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nPer continuare seleziona 'Avanti' o 'Annulla' per uscire dall'installazione.
-it.SelfContainedx86=Verrà installata la versione standalone di %1 %2 32 bit.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nPer continuare seleziona 'Avanti' o 'Annulla' per uscire dall'installazione.
+it.DeleteConfigFiles=Vuoi rimuovere le impostazioni, i file cronologia e le voci del registro?%n%nSe hai intenzione di reinstallare il programma seleziona 'No'.
+it.NotSelfContained64=Verrà installata la versione x64 (64 bit) dipendente dal framework %1 %2.%n%nQuesta versione richiede che sia già installato .NET 10 Desktop Runtime.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nPer continuare seleziona 'Avanti' o 'Annulla' per uscire dall'installazione.
+it.SelfContainedx64=Verrà installata la versione x64 (64 bit) standalone portatile di %1 %2.%n%nPrima di continuare l'installazione ti consigliamo di chiudere tutte le altre applicazioni.%n%nPer continuare seleziona 'Avanti' o 'Annulla' per uscire dall'installazione.
 it.ViewReadme=Visualizza file 'ReadMe'
 ;
 ;
 ko.AppIsRunning=가 실행 중입니다. 설치를 계속하려면 닫으세요.
-ko.DeleteConfigFiles=설정 파일을 제거하시겠습니까?%n%n다시 설치할 계획인 경우 '아니오'를 선택하세요.
-ko.NotSelfContained=이렇게 하면 %1 버전 %2.%n%n의 표준 버전이 설치됩니다.%n%n이 버전은 .NET 10 데스크톱 런타임의 기존 설치가 필요하며 x64 및 x86 시스템과 모두 호환됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
-ko.SelfContainedx64=이렇게 하면 %1 버전 %2.%n%n의 독립 실행형 x64 (64비트) 버전이 설치됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
-ko.SelfContainedx86=이렇게 하면 %1 버전 %2의 독립 실행형 x86 (32비트) 버전이 설치됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
+ko.DeleteConfigFiles=설정 및 기록 파일과 레지스트리 항목을 제거하시겠습니까?%n%n프로그램을 다시 설치할 계획이면 '아니오'를 선택하세요.
+ko.NotSelfContained64=이렇게 하면 %1 버전 %2의 프레임워크 종속 x64 (64비트) 버전이 설치됩니다.%n%n이 버전은 .NET 10 Desktop Runtime의 기존 설치가 필요합니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫는 것이 좋습니다.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
+ko.SelfContainedx64=이렇게 하면 %1 버전 %2의 독립 실행형 x64 (64비트) 버전이 설치됩니다.%n%n계속하기 전에 다른 모든 응용 프로그램을 닫으세요.%n%n계속하려면 '다음'을 클릭하거나 설치 프로그램을 종료하려면 '취소'를 클릭합니다.
 ko.ViewReadme=ReadMe 파일 보기
 ;
 ;
 nl.AppIsRunning=wordt uitgevoerd, sluit deze dan af om door te gaan met de installatie.
-nl.DeleteConfigFiles=Wil je de instellingen en uitsluitingsbestanden verwijderen?%n%nSelecteer 'Nee' als je van plan bent om opnieuw te installeren.
-nl.NotSelfContained=Hiermee wordt de standaardversie van %1 versie %2 geïnstalleerd.%n%n%nDeze versie vereist een bestaande installatie van .NET 10 Desktop Runtime en is compatibel met zowel x64- als x86-systemen.%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'volgende' om door te gaan of op 'annuleren' om de installatie af te sluiten.
-nl.SelfContainedx64=Hiermee wordt de portable x64 (64-bits) versie van %1 versie %2 geïnstalleerd.%n%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'volgende' om door te gaan of op 'annuleren' om de installatie af te sluiten.
-nl.SelfContainedx86=Hiermee wordt de portable x86 (32-bits) versie van %1 versie %2 geïnstalleerd.%n%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'volgende' om door te gaan of op 'annuleren' om de installatie af te sluiten.
+nl.DeleteConfigFiles=Wilt u de instellingen, gegevensbestanden en registerwaarden verwijderen?%n%nKies 'NEE' als u het programma opnieuw wilt installeren.
+nl.NotSelfContained64=Hiermee wordt de x64 (64-bits) frameworkafhankelijke versie van %1 versie %2 geïnstalleerd.%n%nDeze versie vereist een bestaande installatie van .NET 10 Desktop Runtime.%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'Volgende' om door te gaan of op 'Annuleren' om de installatie af te sluiten.
+nl.SelfContainedx64=Hiermee wordt de draagbare x64 (64-bits) zelfstandige versie van %1 versie %2 geïnstalleerd.%n%nHet wordt aanbevolen om alle andere toepassingen te sluiten voordat u doorgaat.%n%nKlik op 'Volgende' om door te gaan of op 'Annuleren' om de installatie af te sluiten.
 nl.ViewReadme=Open de ReadMe file
 ;
 ;
 pt.AppIsRunning=está em execução, feche-o para continuar com a instalação.
 pt.DeleteConfigFiles=Você deseja remover os arquivos de configurações?%n%nSelecione 'Não' se você planeja reinstalar.
-pt.NotSelfContained=Isto instalará a versão padrão do %1 versão %2.%n%nEsta versão necessita de uma instalação existente do .NET 10 Desktop Runtime que é compatível com sistemas de 32 e 64 bits.%n%nÉ recomendado que você feche todas os outros aplicativos antes de continuar.%n%nClique 'Avançar' para continuar ou 'Cancelar' para sair da instalação.
-pt.SelfContainedx64=Isto instalará aversão de 64 bits do %1 versão %2.%n%nÉ recomendado que você feche todas os outros aplicativos antes de continuar.%n%nClique 'Avançar' para continuar ou 'Cancelar' para sair da instalação.
-pt.SelfContainedx86=Isto instalará aversão de 32 bits do %1 versão %2.%n%nÉ recomendado que você feche todas os outros aplicativos antes de continuar.%n%nClique 'Avançar' para continuar ou 'Cancelar' para sair da instalação.
+pt.NotSelfContained64=Isso instalará a versão x64 (64 bits) dependente da estrutura %1 versão %2.%n%nEsta versão requer uma instalação existente do .NET 10 Desktop Runtime.%n%nRecomenda-se fechar todos os outros aplicativos antes de continuar.%n%nClique em 'Avançar' para continuar ou em 'Cancelar' para sair da Instalação.
+pt.SelfContainedx64=Isso instalará a versão x64 (64 bits) independente do %1 versão %2.%n%nRecomenda-se fechar todos os outros aplicativos antes de continuar.%n%nClique em 'Avançar' para continuar ou em 'Cancelar' para sair da Instalação.
 pt.ViewReadme=Ver o arquivo leiame
 ;
 ;
 sk.AppIsRunning=beží, zatvorte ho, aby ste mohli pokračovať v inštalácii.
 sk.DeleteConfigFiles=Chcete odstrániť súbory nastavení?%n%nAk plánujete preinštalovať, vyberte 'Nie'.
-sk.NotSelfContained=Tým sa nainštaluje samostatná x64 (64-bitová) verzia %1 verzie %2.%n%nPred pokračovaním sa odporúča zatvoriť všetky ostatné aplikácie.%n%nKliknite na tlačidlo "Ďalej" pre pokračovanie alebo na "Zrušiť" na ukončenie inštalácie.
-sk.SelfContainedx64=Tým sa nainštaluje x64 (64-bitová) verzia %1 verzia %2.%n%nPred pokračovaním sa odporúča zavrieť všetky ostatné aplikácie.%n%nKliknite na tlačidlo "Ďalej" pre pokračovanie alebo na tlačidlo "Zrušiť" na ukončenie inštalácie.
-sk.SelfContainedx86=Tým sa nainštaluje x86 (32-bitová) verzia %1 verzia %2.%n%nPred pokračovaním sa odporúča zatvoriť všetky ostatné aplikácie.%n%nKliknite na tlačidlo "Ďalej" pre pokračovanie alebo na tlačidlo "Zrušiť" na ukončenie inštalácie.
+sk.NotSelfContained64=Týmto sa nainštaluje x64 (64-bitová) verzia %1 verzie %2 závislá od frameworku.%n%nTáto verzia vyžaduje existujúcu inštaláciu .NET 10 Desktop Runtime.%n%nPred pokračovaním sa odporúča zatvoriť všetky ostatné aplikácie.%n%nKliknite na tlačidlo „Ďalej“ pre pokračovanie alebo na tlačidlo „Zrušiť“ pre ukončenie inštalácie.
+sk.SelfContainedx64=Týmto sa nainštaluje samostatná x64 (64-bitová) verzia %1 verzie %2.%n%nPred pokračovaním sa odporúča zatvoriť všetky ostatné aplikácie.%n%nKliknite na tlačidlo „Ďalej“ pre pokračovanie alebo na tlačidlo „Zrušiť“ pre ukončenie inštalácie.
 sk.ViewReadme=Zobraziť súbor ReadMe

--- a/MyScheduledTasks/MyScheduledTasks.csproj
+++ b/MyScheduledTasks/MyScheduledTasks.csproj
@@ -16,11 +16,18 @@
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
+  <!-- x64 Only-->
+  <PropertyGroup>
+    <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
+  
   <!-- Set version and prerelease string (if needed) -->
   <PropertyGroup>
     <VersionValidate>true</VersionValidate>
-    <Version>0.10.0</Version>
-    <VersionPrerelease></VersionPrerelease>
+    <Version>0.11.0</Version>
+    <VersionPrerelease>Beta.1</VersionPrerelease>
   </PropertyGroup>
   
   <!-- Manifest - Run app elevated -->

--- a/MyScheduledTasks/Properties/PublishProfiles/Framework_Dependent_x64.pubxml
+++ b/MyScheduledTasks/Properties/PublishProfiles/Framework_Dependent_x64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishDir>V:\Publish\MyScheduledTasks\Framework_Dependent</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/MyScheduledTasks/Properties/PublishProfiles/Self_Contained_x64.pubxml
+++ b/MyScheduledTasks/Properties/PublishProfiles/Self_Contained_x64.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>V:\Publish\MyScheduledTasks\Self_Contailed_x64</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <_TargetId>Folder</_TargetId>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
+  </PropertyGroup>
+</Project>

--- a/MyScheduledTasks/Views/AboutPage.xaml
+++ b/MyScheduledTasks/Views/AboutPage.xaml
@@ -86,11 +86,15 @@
 
                 <TextBlock Grid.Row="1" Grid.Column="0"
                            Text="{DynamicResource About_Version}" />
-                <TextBlock Grid.Row="1" Grid.Column="2"
+                <StackPanel Grid.Row="1" Grid.Column="2"
+                            Orientation="Horizontal">
+                    <TextBlock 
                            Text="{x:Static local:BuildInfo.VersionString}"
                            TextWrapping="Wrap"
                            ToolTip="{x:Static helpers:AppInfo.AppProductVersion}"
                            ToolTipService.Placement="Top" />
+                    <TextBlock Text="{Binding Source={x:Static helpers:AppInfo.Architecture}, StringFormat='({0})'}" Margin="10,0,0,0" />
+                </StackPanel>
 
                 <TextBlock Grid.Row="2" Grid.Column="0"
                            Text="{DynamicResource About_CreatedBy}" />


### PR DESCRIPTION
Migrate project to x64 only

- Ensure all .pubxml files are versioned via .gitignore update
- Remove solution-to-project platform mapping; set project to x64
- Revise Inno Setup script for FD_x64 and new install messages
- Update localization: clarify messages, improve translations
- Set csproj platform/runtime to x64/win-x64, bump to 0.11.0 Beta.1
- Show version and architecture on About page
- Add publish profiles for framework-dependent and self-contained x64