### PR TITLE
Refactor clipboard handling with async and retry logic

### DIFF
--- a/MyScheduledTasks/Helpers/ClipboardHelper.cs
+++ b/MyScheduledTasks/Helpers/ClipboardHelper.cs
@@ -1,31 +1,57 @@
 ﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
 
-using static Vanara.PInvoke.User32;
+using System.Windows.Threading;
 
 namespace MyScheduledTasks.Helpers;
 
 internal static class ClipboardHelper
 {
     #region Copy text to clipboard
-    private const uint _const_CF_UNICODETEXT = 13;
-
     /// <summary>
-    /// Copies text to clipboard using Vanara PInvoke instead of DllImport
+    /// Copy to clipboard with retry logic to handle potential exceptions when the clipboard is busy.
+    /// <param name="text">The text to be copied to the clipboard.</param>
+    /// <param name="maxRetries"> is the maximum number of retry attempts.</param>
+    /// <param name="delayMs"> is the delay between retries in milliseconds.</param>
+    /// <returns>True if the text was successfully copied to the clipboard; otherwise, false.</returns>
     /// </summary>
-    /// <param name="text">Text to be placed in the Windows clipboard</param>
-    public static bool CopyTextToClipboard(string text)
+    public static async System.Threading.Tasks.Task<bool> CopyTextToClipboardAsync(string? text, int maxRetries = 10, int delayMs = 50)
     {
-        if (!OpenClipboard(IntPtr.Zero) || text.Length < 1)
+        if (string.IsNullOrEmpty(text) || maxRetries <= 0 || delayMs <= 0)
         {
             return false;
         }
 
-        IntPtr global = Marshal.StringToHGlobalUni(text);
+        Dispatcher? dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null)
+        {
+            return false;
+        }
 
-        _ = SetClipboardData(_const_CF_UNICODETEXT, global);
-        _ = CloseClipboard();
-
-        return true;
+        for (int attempt = 1; attempt <= maxRetries; attempt++)
+        {
+            try
+            {
+                if (dispatcher.CheckAccess())
+                {
+                    Clipboard.SetText(text);
+                }
+                else
+                {
+                    await dispatcher.InvokeAsync(() => Clipboard.SetText(text));
+                }
+                return true;
+            }
+            catch (ExternalException) when (attempt < maxRetries)
+            {
+                await System.Threading.Tasks.Task.Delay(delayMs).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, $"Error copying text to clipboard. {ex.Message}");
+                return false;
+            }
+        }
+        return false;
     }
     #endregion Copy text to clipboard
 }

--- a/MyScheduledTasks/Languages/Strings.en-US.xaml
+++ b/MyScheduledTasks/Languages/Strings.en-US.xaml
@@ -187,6 +187,7 @@
     <sys:String x:Key="MsgText_AppUpdateNoneFound">No newer releases were found.</sys:String>
     <sys:String x:Key="MsgText_ColumnSortCleared">Column sort cleared</sys:String>
     <sys:String x:Key="MsgText_CopiedToClipboardItem">Item was copied to the clipboard</sys:String>
+    <sys:String x:Key="MsgText_CopyToClipboardFail">Copy to clipboard failed</sys:String>
     <sys:String x:Key="MsgText_Deleted">Deleted {0}.</sys:String>
     <sys:String x:Key="MsgText_DeleteError">Error attempting to delete {0}.</sys:String>
     <sys:String x:Key="MsgText_DeleteNoneSelected">Nothing selected to delete.</sys:String>
@@ -415,5 +416,9 @@
     <!-- Begin changes on 2026/07/08 @ 02:00 UTC -->
     <!-- U | About_BuildDate - Changed 'Build' to 'Commit' -->
     <!-- End of changes on 2026/07/08 @ 02:00 UTC -->
+
+    <!-- Begin changes on 2026/08/03 @ 23:00 UTC -->
+    <!-- A | MsgText_CopyToClipboardFail -->
+    <!-- End of changes on 2026/08/03 @ 23:00 UTC -->
 
 </ResourceDictionary>

--- a/MyScheduledTasks/MyScheduledTasks.csproj
+++ b/MyScheduledTasks/MyScheduledTasks.csproj
@@ -70,7 +70,6 @@
     <PackageReference Include="NLog" Version="6.1.4" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="TaskScheduler" Version="2.12.2" />
-    <PackageReference Include="Vanara.PInvoke.User32" Version="5.0.5" />
     <PackageReference Include="VersionInfoGenerator" Version="3.2.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/MyScheduledTasks/ViewModels/NavigationViewModel.cs
+++ b/MyScheduledTasks/ViewModels/NavigationViewModel.cs
@@ -591,7 +591,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
     /// Copy (nearly) any text in a TextBlock to the clipboard on right mouse button up.
     /// </summary>
     [RelayCommand]
-    private static void RightMouseUp(MouseButtonEventArgs e)
+    private static async System.Threading.Tasks.Task RightMouseUp(MouseButtonEventArgs e)
     {
         try
         {
@@ -609,18 +609,20 @@ internal sealed partial class NavigationViewModel : ObservableObject
             }
 
             // Try copy to clipboard
-            if (!ClipboardHelper.CopyTextToClipboard(text.Text))
+            if (!await ClipboardHelper.CopyTextToClipboardAsync(text.Text))
             {
+                SnackbarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopyToClipboardFail"));
                 return;
             }
 
             // Display snackbar message
             SnackbarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopiedToClipboardItem"));
-            _log.Debug($"{text.Text.Length} bytes copied to the clipboard");
+            _log.Debug($"{text.Text.Length} characters copied to the clipboard");
         }
         catch (Exception ex)
         {
             _log.Error(ex, $"Right-click event handler failed. {ex.Message}");
+            SnackbarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopyToClipboardFail"));
         }
     }
     #endregion Right mouse button


### PR DESCRIPTION
Refactor clipboard handling with async and retry logic

- Replaced ClipboardHelper.CopyTextToClipboard with async CopyTextToClipboardAsync using retry logic for better reliability.
- Updated NavigationViewModel's RightMouseUp command to use the new async clipboard method and show a snackbar message on failure.
- Added MsgText_CopyToClipboardFail resource for user feedback.
- Removed Vanara.PInvoke.User32 dependency.