### PR TITLE
Remove CommandLineArgumentsParser dependency

### DIFF
--- a/MyScheduledTasks/GlobalUsings.cs
+++ b/MyScheduledTasks/GlobalUsings.cs
@@ -14,7 +14,6 @@ global using System.Linq;
 global using System.Media;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
-global using System.Runtime.Versioning;
 global using System.Security.Principal;
 global using System.Text;
 global using System.Text.Json;
@@ -25,9 +24,6 @@ global using System.Windows.Data;
 global using System.Windows.Input;
 global using System.Windows.Markup;
 global using System.Windows.Media;
-
-global using CommandLineParser.Arguments;
-global using CommandLineParser.Exceptions;
 
 global using CommunityToolkit.Mvvm.ComponentModel;
 global using CommunityToolkit.Mvvm.Input;

--- a/MyScheduledTasks/Helpers/CommandLineHelpers.cs
+++ b/MyScheduledTasks/Helpers/CommandLineHelpers.cs
@@ -5,41 +5,87 @@ namespace MyScheduledTasks.Helpers;
 internal static class CommandLineHelpers
 {
     #region Properties
-    public static string? CommandLineParserError { get; private set; }
     public static bool Administrator { get; private set; }
     public static bool Hide { get; private set; }
     #endregion Properties
 
-    #region Command line parameters
-    public static void ProcessCommandLine()
+    #region Parse command line parameters
+    /// <summary>
+    /// Parses the command line arguments and sets the corresponding properties.
+    /// </summary>
+    /// <remarks>
+    /// This method does not consider multiple arguments since the administrator and hide arguments are expected to be mutually exclusive.
+    /// If the administrator argument is present, the application will restart with elevated privileges, and the hide argument will be ignored.
+    /// </remarks>
+    public static void ParseCommandLine()
     {
-        using CommandLineParser.CommandLineParser parser = new();
-        SwitchArgument hideArgument = new('h',
-                                          "hide",
-                                          string.Empty,
-                                          false);
-        SwitchArgument adminArgument = new('a',
-                                           "administrator",
-                                           string.Empty,
-                                           false);
-        parser.Arguments.Add(hideArgument);
-        parser.Arguments.Add(adminArgument);
-        parser.AcceptSlash = true;
-        parser.IgnoreCase = true;
+        Administrator = false;
+        Hide = false;
+
         try
         {
-            parser.ParseCommandLine(App.Args);
-            Hide = hideArgument.Value;
-            Administrator = adminArgument.Value;
+            foreach (string rawArgument in App.Args)
+            {
+                if (string.IsNullOrWhiteSpace(rawArgument))
+                {
+                    continue;
+                }
+
+                string argument = rawArgument.Trim();
+                if (IsHideArgument(argument))
+                {
+                    Hide = true;
+                    continue;
+                }
+                if (IsAdministratorArgument(argument))
+                {
+                    Administrator = true;
+                    continue;
+                }
+
+                _log.Warn($"Unknown command line argument: \"{argument}\"");
+            }
         }
-        catch (UnknownArgumentException e)
+        catch (Exception ex)
         {
-            CommandLineParserError = "Command line argument: " + e.Message;
-        }
-        catch (Exception e)
-        {
-            CommandLineParserError = "Command line argument: " + e.Message + e.StackTrace;
+            _log.Error(ex, $"Error processing command line arguments. {ex.Message}");
         }
     }
-    #endregion Command line parameters
+    #endregion Parse command line parameters
+
+    #region Argument checks
+    /// <summary>
+    /// Determines whether the specified argument is a hide argument.
+    /// </summary>
+    /// <returns>true if the argument is a hide argument; otherwise, false.</returns>
+    private static bool IsHideArgument(string argument)
+    {
+        string normalized = NormalizeArgument(argument);
+        return normalized.Equals("h", StringComparison.Ordinal) ||
+               normalized.Equals("hide", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether the specified argument is an administrator argument.
+    /// </summary>
+    /// <returns>true if the argument is an administrator argument; otherwise, false.</returns>
+    private static bool IsAdministratorArgument(string argument)
+    {
+        string normalized = NormalizeArgument(argument);
+        return normalized.Equals("a", StringComparison.Ordinal) ||
+               normalized.Equals("administrator", StringComparison.Ordinal);
+    }
+    #endregion Argument checks
+
+    /// <summary>
+    /// Normalizes the specified argument by trimming whitespace, removing all leading '-'s or '/'s, and converting to lowercase.
+    /// </summary>
+    /// <remarks>
+    /// This method does not consider all possible command line argument formats, but it is sufficient for the expected arguments in this application.
+    /// </remarks>
+    /// <returns>The normalized argument string.</returns>
+    private static string NormalizeArgument(string argument)
+    {
+         return argument.Trim().TrimStart('-', '/').ToLowerInvariant();
+    }
 }

--- a/MyScheduledTasks/Helpers/MainWindowHelpers.cs
+++ b/MyScheduledTasks/Helpers/MainWindowHelpers.cs
@@ -163,12 +163,7 @@ internal static class MainWindowHelpers
     #region Process command line options
     private static void ProcessCommandLine()
     {
-        CommandLineHelpers.ProcessCommandLine();
-
-        if (CommandLineHelpers.CommandLineParserError is not null)
-        {
-            _log.Warn(CommandLineHelpers.CommandLineParserError);
-        }
+        CommandLineHelpers.ParseCommandLine();
 
         if (CommandLineHelpers.Administrator)
         {
@@ -178,12 +173,11 @@ internal static class MainWindowHelpers
 
         if (CommandLineHelpers.Hide)
         {
-            _log.Debug("Argument \"hide\" specified. Scheduled tasks will be checked but window will only be shown if needed.");
-            // hide the window
             _mainWindow!.Visibility = Visibility.Hidden;
+            _log.Debug("Argument \"hide\" specified. Scheduled tasks will be checked but window will only be shown if needed.");
             bool showMainWindow = false;
 
-            // Only write so log file when the window is hidden
+            // Loop through the scheduled tasks and check if any of the checked tasks have a non-zero result. If so, show the window.
             foreach (ScheduledTask task in ScheduledTask.TaskList)
             {
                 _log.Debug($"{task.TaskName} result = {task.TaskResultShort}");

--- a/MyScheduledTasks/MyScheduledTasks.csproj
+++ b/MyScheduledTasks/MyScheduledTasks.csproj
@@ -64,7 +64,6 @@
   <!-- Packages -->
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="CommandLineArgumentsParser" Version="3.0.23" />
     <PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
     <PackageReference Include="MaterialDesignThemes" Version="5.3.2" />
     <PackageReference Include="NLog" Version="6.1.4" />

--- a/MyScheduledTasks/ReadMe.txt
+++ b/MyScheduledTasks/ReadMe.txt
@@ -250,8 +250,6 @@ My Scheduled Tasks was written by Tim Kennedy.
 
 My Scheduled Tasks uses the following packages:
 
-    * Command Line Parser https://github.com/commandlineparser/commandline
-
     * Community Toolkit MVVM https://github.com/CommunityToolkit/dotnet
 
     * GongSolutions.WPF.DragDrop https://github.com/punker76/gong-wpf-dragdrop


### PR DESCRIPTION
Remove CommandLineArgumentsParser dependency

- Replaced CommandLineArgumentsParser with custom logic in CommandLineHelpers for parsing "hide" and "administrator" arguments.
- Removed related global usings and project references. 
- Updated MainWindowHelpers and ReadMe.txt to reflect these changes, simplifying command line handling and reducing external dependencies.