### PR TITLE
Refactor Translations section with Expander control

### DIFF
--- a/MyScheduledTasks/Configuration/UserSettings.cs
+++ b/MyScheduledTasks/Configuration/UserSettings.cs
@@ -165,6 +165,9 @@ public partial class UserSettings : ConfigManager<UserSettings>
     [ObservableProperty]
     private ThemeType _systemDarkTheme = ThemeType.Darker;
 
+    [ObservableProperty]
+    private bool _translatorExpanderOpen = true;
+
     /// <summary>
     /// Defined language to use in the UI.
     /// </summary>

--- a/MyScheduledTasks/Views/AboutPage.xaml
+++ b/MyScheduledTasks/Views/AboutPage.xaml
@@ -216,52 +216,67 @@
                 <!--#endregion-->
 
                 <!--#region Translations-->
-                <Grid Grid.Row="12" Grid.Column="0">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="26" />
-                        <RowDefinition Height="26" />
-                        <RowDefinition Height="*" />
-                    </Grid.RowDefinitions>
-                    <TextBlock Grid.Row="0"
-                               Text="{DynamicResource About_Translations}" />
+                <Expander Grid.Row="11" Grid.Column="0"
+                          Grid.ColumnSpan="3"
+                          Margin="0,10,0,10"
+                          materialDesign:ExpanderAssist.ExpanderButtonPosition="Start"
+                          materialDesign:ExpanderAssist.HorizontalHeaderPadding="5,10"
+                          IsExpanded="{Binding TranslatorExpanderOpen,
+                                               Source={x:Static config:UserSettings.Setting}}">
+                    <Expander.Header>
+                        <Grid>
+                            <TextBlock Margin="10,0"
+                                       FontWeight="SemiBold"
+                                       Text="{DynamicResource About_Translations}"
+                                       TextWrapping="Wrap" />
+                        </Grid>
+                    </Expander.Header>
+                    <Grid Margin="40,0,20,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="20" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="20" />
+                        </Grid.RowDefinitions>
+                        <DataGrid Grid.Row="0"
+                                  HorizontalAlignment="Left"
+                                  d:ItemsSource="{d:SampleData ItemCount=4}"
+                                  materialDesign:DataGridAssist.CellPadding="15,5,15,5"
+                                  materialDesign:DataGridAssist.SelectedCellBorderBrush="Transparent"
+                                  AutoGenerateColumns="False"
+                                  Background="{DynamicResource MaterialDesign.Brush.Card.Background}"
+                                  BorderThickness="2"
+                                  FontSize="{Binding SelectedFontSize,
+                                                     Source={x:Static config:UserSettings.Setting}}"
+                                  HeadersVisibility="None"
+                                  IsReadOnly="True"
+                                  ItemsSource="{Binding AnnotatedLanguageList,
+                                                        Mode=OneWay}">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Binding="{Binding LanguageNative}"
+                                                    MinWidth="130" />
+                                <DataGridTextColumn Binding="{Binding LanguageCode}"
+                                                    MinWidth="60" />
+                                <DataGridTextColumn Binding="{Binding Contributor}"
+                                                    MinWidth="200" />
+                                <DataGridTextColumn Binding="{Binding Note}"
+                                                    MinWidth="90"
+                                                    CellStyle="{StaticResource AlignRight}" />
+                            </DataGrid.Columns>
+                        </DataGrid>
 
-                    <TextBlock Grid.Row="1">
-                        <Hyperlink Command="{Binding GoToWebPageCommand}"
-                                   CommandParameter="https://github.com/Timthreetwelve/MyScheduledTasks/wiki/Contribute-a-Translation"
-                                   Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
-                                   ToolTip="{DynamicResource About_ContributeToolTip}"
-                                   ToolTipService.Placement="Top">
-                            <TextBlock Text="{DynamicResource About_Contribute}" />
-                        </Hyperlink>
-                    </TextBlock>
-                </Grid>
-
-
-                <DataGrid Grid.Row="12" Grid.Column="2"
-                          HorizontalAlignment="Left"
-                          materialDesign:DataGridAssist.CellPadding="{Binding RowSpacing,
-                                                                              Source={x:Static config:UserSettings.Setting},
-                                                                              Converter={StaticResource Spacing}}"
-                          AutoGenerateColumns="False"
-                          Background="{DynamicResource MaterialDesign.Brush.Card.Background}"
-                          BorderThickness="1"
-                          CellStyle="{StaticResource DgCellStyle}"
-                          HeadersVisibility="None"
-                          IsReadOnly="True"
-                          ItemsSource="{Binding AnnotatedLanguageList,
-                                                Mode=OneWay}">
-                    <DataGrid.Columns>
-                        <DataGridTextColumn Binding="{Binding LanguageNative}"
-                                            MinWidth="110" />
-                        <DataGridTextColumn Binding="{Binding LanguageCode}"
-                                            MinWidth="90" />
-                        <DataGridTextColumn Binding="{Binding Contributor}"
-                                            MinWidth="100" />
-                        <DataGridTextColumn Binding="{Binding Note}"
-                                            MinWidth="90"
-                                            CellStyle="{StaticResource AlignRight}" />
-                    </DataGrid.Columns>
-                </DataGrid>
+                        <TextBlock Grid.Row="2">
+                            <Hyperlink Command="{Binding GoToWebPageCommand}"
+                                       CommandParameter="https://github.com/Timthreetwelve/MyScheduledTasks/wiki/Contribute-a-Translation"
+                                       Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                                       ToolTip="{DynamicResource About_ContributeToolTip}"
+                                       ToolTipService.Placement="Top">
+                                <InlineUIContainer>
+                                    <TextBlock Text="{DynamicResource About_Contribute}" />
+                                </InlineUIContainer>
+                            </Hyperlink></TextBlock>
+                    </Grid>
+                </Expander>
 
                 <!--#endregion-->
             </Grid>


### PR DESCRIPTION
Refactor Translations section with Expander control

- Replace Grid/DataGrid layout in AboutPage.xaml with a MaterialDesign Expander bound to new UserSettings.TranslatorExpanderOpen. 
- Nest DataGrid and Contribute link inside Expander for better UI organization. 
- Remove redundant DataGrid definitions and update UserSettings with the new property.